### PR TITLE
Check and fix

### DIFF
--- a/oddfisher/fisher.py
+++ b/oddfisher/fisher.py
@@ -277,6 +277,7 @@ def get_pvalue(
     lower_tail_val = compute_pnhyper(
         support,
         x,
+        x,
         M,
         n,
         N,
@@ -470,8 +471,27 @@ def run_fisher_exact(
         odd_ratio=odd_ratio,
         alternative=alternative,
     )
-    print(confidence_interval)
-    return estimate, confidence_interval
+
+    pvalues = dict(zip(
+        ["two-sided", "less", "greater"],
+        get_pvalue(support, x, M, M - n, N, odd_ratio=odd_ratio)
+    ))
+    return estimate, confidence_interval, pvalues
+
+
+def print_result(args, odd_ratio, ci, pvals):
+    print("2x2 contingency table")
+    print(f"{args.a}, {args.c}")
+    print(f"{args.b}, {args.d}")
+    print("-------------------")
+    print(f"odd-raio: {args.odd_ratio}")
+    print(f"alternative: {args.alternative}")
+    print("-------------------")
+    print("Results")
+    print("-------------------")
+    print(f"p-value: {pvals}")
+    print(f"confidence interval at {args.conf_level}: {ci}")
+    print(f"odds ratio: {odd_ratio}")
 
 
 def arg_parser() -> argparse.ArgumentParser:
@@ -493,23 +513,13 @@ def arg_parser() -> argparse.ArgumentParser:
 
 def main():
     args = arg_parser().parser()
-    pval, ci = run_fisher_exact(
+    odd_ratio, ci, pvals = run_fisher_exact(
         data = np.array([args.a, args.b, args.c, args.d]).reshape((2, 2)),
         odd_ratio = args.odd_ratio,
         conf_level=args.conf_level,
         alternative=args.alternative,
     )
-
-    print("2x2 contingency table")
-    print(f"{args.a}, {args.c}")
-    print(f"{args.b}, {args.d}")
-    print("-------------------")
-    print(f"odd-raio: {args.odd_ratio}")
-    print(f"alternative: {args.alternative}")
-    print("-------------------")
-    print(f"p-value: {pval}")
-    print(f"confidence interval at {args.conf_level}: {ci}")
-
+    print_result(args, odd_ratio, ci, pvals)
 
 
 def cli(*, argv: list[str] | None = None, args: argparse.Namespace | None = None) -> None:
@@ -530,12 +540,13 @@ def cli(*, argv: list[str] | None = None, args: argparse.Namespace | None = None
     if args.command and args.func:
         if args.command == "fisherexact":
             data = np.array([args.a, args.b, args.c, args.d]).reshape((2, 2))
-            args.func(
+            odd_ratio, ci, pvals = args.func(
                 data=data,
                 odd_ratio=args.odd_ratio,
                 conf_level=args.conf_level,
                 alternative=args.alternative,
             )
+            print_result(args, odd_ratio, ci, pvals)
     else:
         parser.print_help()
 


### PR DESCRIPTION
oddfisher fisherexact --odd-ratio 10 1 2 3 4

outputs p-value of 0.07542579075425782
odd ratio 0.6937896639529924
CI @ 0.95, 0.008503581019485222, 20.296323344994953

Equivalent to R fisher.test
> d

     [,1] [,2]
[1,]    1    3
[2,]    2    4

> fisher.test(d, or=10)

data:  d
p-value = 0.07543
alternative hypothesis: true odds ratio is not equal to 10
95 percent confidence interval:
  0.008512238 20.296715040
sample estimates:
odds ratio
  0.693793